### PR TITLE
US572083: Migrating BOM version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
             <dependency>
                 <groupId>com.github.cafapi</groupId>
                 <artifactId>caf-dependency-management-bom</artifactId>
-                <version>3.1.0-412</version>
+                <version>3.3.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=572083

Gson upgraded to 2.9.1 [caf-dependency-management-bom](https://github.com/CAFapi/caf-dependency-management-bom/blob/27b72cd20dc15fc661cd6dc2c16db7449912d7df/pom.xml#L90). Hence BOM version is being migrated here.