### PR TITLE
US870109: CVE-2023-0833: Update okhttp to jersey

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
             <dependency>
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-message-prioritization-rerouting</artifactId>
-                <version>1.3.0-181</version>
+                <version>1.4.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=870109