### PR TITLE
I948127: Update release-notes to introduce JVM OutOfMemoryError args

### DIFF
--- a/release-notes-5.2.0.md
+++ b/release-notes-5.2.0.md
@@ -6,5 +6,6 @@ ${version-number}
 #### New Features
 - US929026: Updated to run on Java 21.
 - US952036: Image is now built on Oracle Linux.
+- I948127: JVM arguments introduced for diagnosing OutOfMemoryError.
 
 #### Known Issues


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=948127