### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/language-detection-cld2/pom.xml
+++ b/language-detection-cld2/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>language-detection-cld2</artifactId>
+    <name>language-detection-cld2</name>
 
     <parent>
         <groupId>com.github.cafdataprocessing.workers.languagedetection</groupId>

--- a/language-detection/pom.xml
+++ b/language-detection/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>language-detection</artifactId>
+    <name>language-detection</name>
 
     <parent>
         <groupId>com.github.cafdataprocessing.workers.languagedetection</groupId>

--- a/worker-languagedetection-container/pom.xml
+++ b/worker-languagedetection-container/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-languagedetection-container</artifactId>
+    <name>worker-languagedetection-container</name>
     <packaging>pom</packaging>
 
     <parent>

--- a/worker-languagedetection/pom.xml
+++ b/worker-languagedetection/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-languagedetection</artifactId>
+    <name>worker-languagedetection</name>
 
     <parent>
         <groupId>com.github.cafdataprocessing.workers.languagedetection</groupId>


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.

https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1029210